### PR TITLE
#9: added database support using Hibernate

### DIFF
--- a/KNOWN-ISSUES.md
+++ b/KNOWN-ISSUES.md
@@ -1,7 +1,8 @@
 # Known Issues
 
 ## vital
-- Developers currently still need to implement every submodule as dependencies in their plugin to retrieve all of Vitals functionality
+- Developers currently still need to implement every submodule as dependencies in their plugin to retrieve all of Vital's functionality
+- Developers still need to implement transitive dependencies into their project for some modules to work
 
 ## vital-core
 - Developers currently still need to implement the `plugin.yml`
@@ -13,3 +14,6 @@
 
 ## vital-commands
 - `executeBaseCommand()` will currently still be executed on every `INVALID_ARGS` command return state
+
+## vital-databases
+- Developers currently still need to implement hibernate and the mysql-connector-j dependency to their project for Vital to work

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Vital is thoughtfully organized into a series of submodules, each dedicated to a
 - 📋**vital-inventories**: Manage custom inventories efficiently.
 - 📊**vital-scoreboards**: Customize and create scoreboards effortlessly.
 - 🎮**vital-minigames**: Level up your server with complex minigames while keeping code clean and organized.
+- 💾**vital-databases**: Implemented with the Hibernate Framework, this module provides an OOP-Driven JPA Entity System like the Spring Framework, organize your DB-Entities with Repositories and Services!
 
 ## 📦Flexible Integration
 Vital's modular approach empowers developers to pick and choose the specific modules that align with their project requirements.    

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":vital-scoreboards"))
     implementation(project(":vital-players"))
     implementation(project(":vital-minigames"))
+    implementation(project(":vital-databases"))
 }
 
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,3 +12,15 @@ paper-vendor=io.papermc.paper:paper-api:1.20.1-R0.1-SNAPSHOT
 
 # defines the reflections artifact used by all VitalCore modules
 reflection-vendor=org.reflections:reflections:0.10.2
+
+# defines the hibernate artifact used by all database related operations within `vital-databases`
+hibernate-vendor=org.hibernate.orm:hibernate-core:6.1.7.Final
+
+# defines the mysql-connector-j artifact used by all database related operations within `vital-databases`
+mysql-connector-vendor=com.mysql:mysql-connector-j:8.2.0
+
+# defines the jaxb-runtime artiface used by all database related operations within `vital-databases`
+jaxb-runtime-vendor=org.glassfish.jaxb:jaxb-runtime:4.0.2
+
+# defines the jaxb-api artifact used by all database related operations within `vital-databases`
+jaxb-api-vendor=javax.xml.bind:jaxb-api:2.3.1

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,3 +14,4 @@ include(
         "vital-full-sample",
         "vital-standalone-sample"
 )
+include("vital-databases")

--- a/src/main/java/me/xra1ny/vital/Vital.java
+++ b/src/main/java/me/xra1ny/vital/Vital.java
@@ -5,6 +5,7 @@ import me.xra1ny.vital.commands.VitalCommandManager;
 import me.xra1ny.vital.configs.VitalConfigManager;
 import me.xra1ny.vital.core.VitalCore;
 import me.xra1ny.vital.core.VitalListenerManager;
+import me.xra1ny.vital.databases.VitalDatabaseManager;
 import me.xra1ny.vital.holograms.VitalHologramManager;
 import me.xra1ny.vital.inventories.VitalInventoryMenuListener;
 import me.xra1ny.vital.items.VitalItemStackCooldownHandler;
@@ -85,6 +86,13 @@ public final class Vital<T extends JavaPlugin> extends VitalCore<T> {
         final VitalGlobalScoreboardManager vitalGlobalScoreboardManager = new VitalGlobalScoreboardManager();
 
         getVitalComponentManager().registerVitalComponent(vitalGlobalScoreboardManager);
+
+        if(defaultVitalConfig.isVitalDatabaseEnabled()) {
+            // Register VitalDatabaseManager
+            final VitalDatabaseManager vitalDatabaseManager = new VitalDatabaseManager();
+
+            getVitalComponentManager().registerVitalComponent(vitalDatabaseManager);
+        }
     }
 
     /**

--- a/vital-databases/build.gradle.kts
+++ b/vital-databases/build.gradle.kts
@@ -1,0 +1,26 @@
+group = "me.xra1ny.vital"
+version = "1.0"
+
+dependencies {
+    implementation(project(":vital-core"))
+
+    rootProject.property("hibernate-vendor")?.let {
+        implementation(it)
+    }
+
+    rootProject.property("mysql-connector-vendor")?.let {
+        implementation(it)
+    }
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            groupId = group.toString()
+            artifactId = project.name
+            version = version
+
+            from(components["java"])
+        }
+    }
+}

--- a/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabase.java
+++ b/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabase.java
@@ -1,0 +1,61 @@
+package me.xra1ny.vital.databases;
+
+import lombok.Getter;
+import me.xra1ny.vital.core.AnnotatedVitalComponent;
+import me.xra1ny.vital.core.VitalComponentListManager;
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The {@code VitalDatabase} class represents a component responsible for managing database connections and
+ * interacting with database entities. It extends {@code VitalComponentListManager} and implements the
+ * {@code AnnotatedVitalComponent} interface, which is annotated with the {@code VitalDatabaseInfo} annotation.
+ */
+@Getter(onMethod = @__(@NotNull))
+public class VitalDatabase extends VitalComponentListManager<VitalRepository<? extends VitalEntity, ?>> implements AnnotatedVitalComponent<VitalDatabaseInfo> {
+    /**
+     * Stores the configuration for the database connection.
+     */
+    private final Configuration configuration;
+
+    /**
+     * Represents the Hibernate SessionFactory for managing database sessions.
+     */
+    private SessionFactory sessionFactory;
+
+    public VitalDatabase() {
+        final VitalDatabaseInfo vitalDatabaseInfo = getRequiredAnnotation();
+
+        this.configuration = new Configuration().configure(vitalDatabaseInfo.urlToCfgXml());
+    }
+
+    /**
+     * Called when the component is registered. It builds the Hibernate SessionFactory using the provided configuration.
+     */
+    @Override
+    public final void onRegistered() {
+        sessionFactory = configuration.buildSessionFactory();
+    }
+
+    @Override
+    public final void onUnregistered() {
+
+    }
+
+    @Override
+    public final void onVitalComponentRegistered(@NotNull VitalRepository<? extends VitalEntity, ?> vitalRepository) {
+        // Add the annotated class for the managed entity of the VitalRepository to the configuration.
+        configuration.addAnnotatedClass(vitalRepository.managedEntityType());
+    }
+
+    @Override
+    public final void onVitalComponentUnregistered(@NotNull VitalRepository<? extends VitalEntity, ?> vitalRepository) {
+
+    }
+
+    @Override
+    public final Class<VitalDatabaseInfo> requiredAnnotationType() {
+        return VitalDatabaseInfo.class;
+    }
+}

--- a/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabaseInfo.java
+++ b/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabaseInfo.java
@@ -1,0 +1,22 @@
+package me.xra1ny.vital.databases;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The {@code VitalDatabaseInfo} annotation is used to specify the URL to the Hibernate configuration XML file
+ * that defines the database connection settings and entity mappings for a database component. This annotation
+ * should be applied to classes that implement the {@code VitalDatabase} component.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VitalDatabaseInfo {
+    /**
+     * The URL to the .cfg.xml file that configures the Hibernate database connection.
+     *
+     * @return The URL to the .cfg.xml file.
+     */
+    String urlToCfgXml();
+}

--- a/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabaseManager.java
+++ b/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalDatabaseManager.java
@@ -1,0 +1,29 @@
+package me.xra1ny.vital.databases;
+
+import me.xra1ny.vital.core.VitalComponentListManager;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * The {@code VitalDatabaseManager} class manages the registration and unregistration of {@link VitalDatabase} components.
+ * It extends {@link VitalComponentListManager} and provides methods to handle the database components.
+ */
+public final class VitalDatabaseManager extends VitalComponentListManager<VitalDatabase> {
+    @Override
+    public void onRegistered() {
+    }
+
+    @Override
+    public void onUnregistered() {
+
+    }
+
+    @Override
+    public void onVitalComponentRegistered(@NotNull VitalDatabase vitalDatabase) {
+
+    }
+
+    @Override
+    public void onVitalComponentUnregistered(@NotNull VitalDatabase vitalDatabase) {
+
+    }
+}

--- a/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalEntity.java
+++ b/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalEntity.java
@@ -1,0 +1,15 @@
+package me.xra1ny.vital.databases;
+
+import jakarta.persistence.Entity;
+import me.xra1ny.vital.core.AnnotatedVitalComponent;
+
+/**
+ * The {@code VitalEntity} interface represents entities that can be managed by the Vital Framework.
+ * It extends the {@link AnnotatedVitalComponent} interface and enforces the requirement of an {@link Entity} annotation.
+ */
+public interface VitalEntity extends AnnotatedVitalComponent<Entity> {
+    @Override
+    default Class<Entity> requiredAnnotationType() {
+        return Entity.class;
+    }
+}

--- a/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalRepository.java
+++ b/vital-databases/src/main/java/me/xra1ny/vital/databases/VitalRepository.java
@@ -1,0 +1,150 @@
+package me.xra1ny.vital.databases;
+
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.TypedQuery;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import me.xra1ny.vital.core.VitalComponent;
+import org.hibernate.Session;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+/**
+ * The {@code VitalRepository} class represents a generic repository for managing entities in the Vital Framework.
+ * It is intended to provide common database operations for entities.
+ *
+ * @param <Entity> The type of entity to be managed, extending the {@link VitalEntity} interface.
+ * @param <Id>     The type of the entity's identifier.
+ */
+public abstract class VitalRepository<Entity extends VitalEntity, Id> implements VitalComponent {
+    private final VitalDatabase vitalDatabase;
+
+    protected VitalRepository(@NotNull VitalDatabase vitalDatabase) {
+        this.vitalDatabase = vitalDatabase;
+    }
+
+    /**
+     * Checks if an entity with a specific identifier exists.
+     *
+     * @param entityClass The class of the entity.
+     * @param id          The identifier of the entity.
+     * @return {@code true} if an entity with the specified identifier exists, otherwise {@code false}.
+     */
+    public final boolean existsById(@NotNull Class<Entity> entityClass, @NotNull Id id) {
+        return findById(entityClass, id).isPresent();
+    }
+
+    /**
+     * Finds an entity by its identifier.
+     *
+     * @param entityClass The class of the entity.
+     * @param id          The identifier of the entity.
+     * @return An {@link Optional} containing the entity if found, or an empty {@link Optional} if not found.
+     */
+    public final Optional<Entity> findById(@NotNull Class<Entity> entityClass, @NotNull Id id) {
+        final List<Entity> entityList = findAll(entityClass);
+
+        if(entityList.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(entityList.get(0));
+    }
+
+    /**
+     * Finds all entities of a specific class.
+     *
+     * @param entityClass The class of the entity.
+     * @return A {@link List} of entities matching the specified class.
+     */
+    public final List<Entity> findAll(@NotNull Class<Entity> entityClass) {
+        try(Session session = vitalDatabase.getSessionFactory().openSession()) {
+            final CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+            final CriteriaQuery<Entity> criteriaQuery = criteriaBuilder.createQuery(entityClass);
+            final Root<Entity> root = criteriaQuery.from(entityClass);
+
+            criteriaQuery.select(root);
+
+            final TypedQuery<Entity> typedQuery = session.createQuery(criteriaQuery);
+
+            return typedQuery.getResultList();
+        }
+    }
+
+    /**
+     * Checks if entities with specific criteria exist.
+     *
+     * @param entityClass         The class of the entity.
+     * @param columnValueEntries An array of column-value pairs to search for.
+     * @return {@code true} if entities matching the criteria exist, otherwise {@code false}.
+     */
+    public final boolean existsAll(@NotNull Class<Entity> entityClass, @NotNull Map.Entry<String, Object>... columnValueEntries) {
+        return !findAll(entityClass, columnValueEntries).isEmpty();
+    }
+
+    /**
+     * Finds all entities matching specific criteria.
+     *
+     * @param entityClass         The class of the entity.
+     * @param columnValueEntries An array of column-value pairs to search for.
+     * @return A {@link List} of entities matching the specified criteria.
+     */
+    public final List<Entity> findAll(@NotNull Class<Entity> entityClass, @NotNull Map.Entry<String, Object>... columnValueEntries) {
+        try(Session session = vitalDatabase.getSessionFactory().openSession()) {
+            final CriteriaBuilder criteriaBuilder = session.getCriteriaBuilder();
+            final CriteriaQuery<Entity> criteriaQuery = criteriaBuilder.createQuery(entityClass);
+            final Root<Entity> root = criteriaQuery.from(entityClass);
+
+            criteriaQuery.select(root);
+
+            final List<Predicate> predicateList = new ArrayList<>();
+
+            for(Map.Entry<String, Object> columValueEntry : columnValueEntries) {
+                final Predicate predicate = criteriaBuilder.equal(root.get(columValueEntry.getKey()), columValueEntry.getValue());
+
+                predicateList.add(predicate);
+            }
+
+            criteriaQuery.where(predicateList.toArray(new Predicate[0]));
+
+            final TypedQuery<Entity> typedQuery = session.createQuery(criteriaQuery);
+
+            try {
+                return typedQuery.getResultList();
+            }catch (NoResultException e) {
+                return Collections.emptyList();
+            }
+        }
+    }
+
+    /**
+     * Persists an entity in the database.
+     *
+     * @param entity The entity to be persisted.
+     */
+    public final void persist(@NotNull Entity entity) {
+        try(Session session = vitalDatabase.getSessionFactory().openSession()) {
+            session.beginTransaction();
+            session.merge(entity);
+            session.getTransaction().commit();
+        }
+    }
+
+    /**
+     * Removes an entity from the database.
+     *
+     * @param entity The entity to be removed.
+     */
+    public final void remove(@NotNull Entity entity) {
+        try(Session session = vitalDatabase.getSessionFactory().openSession()) {
+            session.beginTransaction();
+            session.remove(entity);
+            session.getTransaction().commit();
+        }
+    }
+
+    public abstract Class<Entity> managedEntityType();
+}

--- a/vital-databases/src/main/resources/hibernate.cfg.xml
+++ b/vital-databases/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <!--
+        Database schema update behavior.
+        'update' means Hibernate will automatically update the database schema based on the entity mappings.
+        -->
+        <property name="hibernate.hbm2ddl.auto">update</property>
+
+        <!--
+        Database connection URL.
+        Replace [ip-address], [port], and [database] with the actual values.
+        -->
+        <property name="hibernate.connection.url">jdbc:mysql://[ip-address]:[port]/[database]</property>
+
+        <!--
+        Database connection username.
+        Replace [username] with the actual database username.
+        -->
+        <property name="hibernate.connection.username">[username]</property>
+
+        <!--
+        Database connection password.
+        Replace [password] with the actual database password.
+        -->
+        <property name="hibernate.connection.password">[password]</property>
+
+        <!-- Show SQL queries in the console (for debugging purposes). -->
+        <property name="hibernate.show_sql">true</property>
+
+        <!--
+        Database dialect. Specify the appropriate dialect for your database.
+        In this case, it's set to MariaDB dialect.
+        -->
+        <property name="hibernate.dialect">org.hibernate.dialect.MariaDBDialect</property>
+    </session-factory>
+</hibernate-configuration>

--- a/vital-full-sample/build.gradle.kts
+++ b/vital-full-sample/build.gradle.kts
@@ -13,4 +13,13 @@ dependencies {
     implementation(project(":vital-scoreboards"))
     implementation(project(":vital-players"))
     implementation(project(":vital-minigames"))
+    implementation(project(":vital-databases"))
+
+    rootProject.property("hibernate-vendor")?.let {
+        implementation(it)
+    }
+
+//    rootProject.property("jaxb-runtime-vendor")?.let {
+//        implementation(it)
+//    }
 }

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/SampleVitalPlugin.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/SampleVitalPlugin.java
@@ -1,12 +1,18 @@
 package me.xra1ny.vital.samples.full;
 
+import me.xra1ny.vital.DefaultVitalConfig;
 import me.xra1ny.vital.Vital;
 import me.xra1ny.vital.commands.VitalCommandManager;
 import me.xra1ny.vital.core.VitalListenerManager;
+import me.xra1ny.vital.databases.VitalDatabaseManager;
 import me.xra1ny.vital.holograms.VitalHologramManager;
 import me.xra1ny.vital.items.VitalItemStackManager;
 import me.xra1ny.vital.samples.full.command.SampleVitalCommand;
+import me.xra1ny.vital.samples.full.listener.SampleVitalDatabaseListener;
 import me.xra1ny.vital.samples.full.listener.SampleVitalListener;
+import me.xra1ny.vital.samples.full.persistence.database.SampleVitalDatabase;
+import me.xra1ny.vital.samples.full.persistence.repository.SampleVitalPlayerRepository;
+import me.xra1ny.vital.samples.full.persistence.service.SampleVitalPlayerService;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class SampleVitalPlugin extends JavaPlugin {
@@ -21,8 +27,41 @@ public final class SampleVitalPlugin extends JavaPlugin {
     @SuppressWarnings("OptionalGetWithoutIsPresent")
     @Override
     public void onEnable() {
+        /*
+         * TODO: NOTE: Consider using the `dependency-injection` pattern, when working with Vital, to organize and keep complex code modular.
+         */
+
         // Here we enable Vital
         vital.enable();
+
+        final DefaultVitalConfig defaultVitalConfig = vital.getVitalComponentManager().getVitalComponent(DefaultVitalConfig.class).get();
+
+        if(defaultVitalConfig.isVitalDatabaseEnabled()) {
+            final VitalDatabaseManager vitalDatabaseManager = vital.getVitalComponentManager().getVitalComponent(VitalDatabaseManager.class).get();
+            final SampleVitalDatabase sampleVitalDatabase = new SampleVitalDatabase();
+            final SampleVitalPlayerRepository sampleVitalPlayerRepository = new SampleVitalPlayerRepository(sampleVitalDatabase);
+
+            // Here we register a new repository for our Database.
+            sampleVitalDatabase.registerVitalComponent(sampleVitalPlayerRepository);
+
+            // Here we register our new Database.
+            vitalDatabaseManager.registerVitalComponent(sampleVitalDatabase);
+
+            // Here we register a new service for our SampleVitalPlayerRepository.
+            final SampleVitalPlayerService sampleVitalPlayerService = new SampleVitalPlayerService(sampleVitalPlayerRepository);
+
+            // Now we can inject the SampleVitalPlayerService into any class instance that depends on its functionality.
+            // Let's say, we have a Command that needs to interact with our database, we can now create a constructor in that Command, to accept the SampleVitalPlayerService
+            // The Command will then utilize the Service to perform actions on DB level.
+            // Using this approach, we can make a cut between direct DB interactions and can include unit tests easily. (Spring approach)
+
+            // Here we register a sample Listener to showcase Database interactions.
+            final SampleVitalDatabaseListener sampleVitalDatabaseListener = new SampleVitalDatabaseListener(sampleVitalPlayerService);
+
+            final VitalListenerManager vitalListenerManager = vital.getVitalComponentManager().getVitalComponent(VitalListenerManager.class).get();
+
+            vitalListenerManager.registerVitalComponent(sampleVitalDatabaseListener);
+        }
 
         // Here we register our Command.
         final VitalCommandManager vitalCommandManager = vital.getVitalComponentManager().getVitalComponent(VitalCommandManager.class).get();
@@ -37,9 +76,5 @@ public final class SampleVitalPlugin extends JavaPlugin {
         final SampleVitalListener sampleVitalListener = new SampleVitalListener(vitalItemStackManager, vitalHologramManager);
 
         vitalListenerManager.registerVitalComponent(sampleVitalListener);
-
-        /*
-         * Consider using the `dependency-injection` pattern, when working with Vital, to organize and keep complex code modular.
-         */
     }
 }

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/listener/SampleVitalDatabaseListener.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/listener/SampleVitalDatabaseListener.java
@@ -1,0 +1,37 @@
+package me.xra1ny.vital.samples.full.listener;
+
+import me.xra1ny.vital.core.VitalListener;
+import me.xra1ny.vital.samples.full.persistence.service.SampleVitalPlayerService;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.jetbrains.annotations.NotNull;
+
+public class SampleVitalDatabaseListener extends VitalListener {
+    private final SampleVitalPlayerService sampleVitalPlayerService;
+
+    public SampleVitalDatabaseListener(@NotNull SampleVitalPlayerService sampleVitalPlayerService) {
+        this.sampleVitalPlayerService = sampleVitalPlayerService;
+    }
+
+    @EventHandler
+    public void onPlayerJoinServer(@NotNull PlayerJoinEvent e) {
+        if(sampleVitalPlayerService.vitalPlayerExistsById(e.getPlayer().getUniqueId())) {
+            e.getPlayer().sendMessage("player already exists in db!");
+
+            return;
+        }
+
+        e.getPlayer().sendMessage("player does not exist in db yet!");
+        e.getPlayer().sendMessage("creating player...");
+
+        sampleVitalPlayerService.createVitalPlayerEntity(e.getPlayer().getUniqueId(), e.getPlayer().getName(), 0, 0);
+
+        e.getPlayer().sendMessage("player successfully created in db!");
+    }
+
+    @EventHandler
+    public void onPlayerLeaveServer(@NotNull PlayerQuitEvent e) {
+        sampleVitalPlayerService.removeVitalPlayerEntityById(e.getPlayer().getUniqueId());
+    }
+}

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/database/SampleVitalDatabase.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/database/SampleVitalDatabase.java
@@ -1,0 +1,11 @@
+package me.xra1ny.vital.samples.full.persistence.database;
+
+import me.xra1ny.vital.databases.VitalDatabase;
+import me.xra1ny.vital.databases.VitalDatabaseInfo;
+
+/**
+ * This class defines that we have a database with meta information defined in `@VitalDatabaseInfo's hibernate.cfg.xml file`
+ */
+@VitalDatabaseInfo(urlToCfgXml = "hibernate.cfg.xml")
+public class SampleVitalDatabase extends VitalDatabase {
+}

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/entity/SampleVitalPlayerEntity.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/entity/SampleVitalPlayerEntity.java
@@ -1,0 +1,45 @@
+package me.xra1ny.vital.samples.full.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import me.xra1ny.vital.databases.VitalEntity;
+
+import java.util.UUID;
+
+/**
+ * This class defines Database entity `row` which holds all data describes in this class.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity(name = "player")
+public class SampleVitalPlayerEntity implements VitalEntity {
+    @Id
+    @Column(name = "UUID")
+    private UUID uniqueId;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @Column(name = "COINS")
+    private long coins;
+
+    @Column(name = "LEVEL")
+    private long level;
+
+    @Override
+    public void onRegistered() {
+
+    }
+
+    @Override
+    public void onUnregistered() {
+
+    }
+}

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/repository/SampleVitalPlayerRepository.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/repository/SampleVitalPlayerRepository.java
@@ -1,0 +1,32 @@
+package me.xra1ny.vital.samples.full.persistence.repository;
+
+import me.xra1ny.vital.databases.VitalDatabase;
+import me.xra1ny.vital.databases.VitalRepository;
+import me.xra1ny.vital.samples.full.persistence.entity.SampleVitalPlayerEntity;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.UUID;
+
+/**
+ * A repository defines which Entity from DB is managed, and which ID is used for the Entity in DB (PK Primary Key).
+ */
+public class SampleVitalPlayerRepository extends VitalRepository<SampleVitalPlayerEntity, UUID> {
+    public SampleVitalPlayerRepository(@NotNull VitalDatabase vitalDatabase) {
+        super(vitalDatabase);
+    }
+
+    @Override
+    public Class<SampleVitalPlayerEntity> managedEntityType() {
+        return SampleVitalPlayerEntity.class;
+    }
+
+    @Override
+    public void onRegistered() {
+
+    }
+
+    @Override
+    public void onUnregistered() {
+
+    }
+}

--- a/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/service/SampleVitalPlayerService.java
+++ b/vital-full-sample/src/main/java/me/xra1ny/vital/samples/full/persistence/service/SampleVitalPlayerService.java
@@ -1,0 +1,87 @@
+package me.xra1ny.vital.samples.full.persistence.service;
+
+import me.xra1ny.vital.samples.full.persistence.entity.SampleVitalPlayerEntity;
+import me.xra1ny.vital.samples.full.persistence.repository.SampleVitalPlayerRepository;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * A Service will perform db actions with the specified repositories on its dependency hierarchy.
+ * We will always call the Service to perform db actions AND NOT THE REPOSITORY DIRECTLY.
+ * <p>
+ * Using this approach, we make sure, that our code is always modular and can be tested later on. (mocking, etc.)
+ */
+public class SampleVitalPlayerService {
+    private final SampleVitalPlayerRepository sampleVitalPlayerRepository;
+
+    public SampleVitalPlayerService(@NotNull SampleVitalPlayerRepository sampleVitalPlayerRepository) {
+        this.sampleVitalPlayerRepository = sampleVitalPlayerRepository;
+    }
+
+    public boolean vitalPlayerExistsById(@NotNull UUID uuid) {
+        return sampleVitalPlayerRepository.existsById(SampleVitalPlayerEntity.class, uuid);
+    }
+
+    public void createVitalPlayerEntity(@NotNull UUID uuid, @NotNull String name, long coins, long level) {
+        final SampleVitalPlayerEntity sampleVitalPlayerEntity = SampleVitalPlayerEntity.builder()
+                .uniqueId(uuid)
+                .name(name)
+                .coins(coins)
+                .level(level)
+                .build();
+
+        sampleVitalPlayerRepository.persist(sampleVitalPlayerEntity);
+    }
+
+    public void removeVitalPlayerEntityById(@NotNull UUID uuid) {
+        final Optional<SampleVitalPlayerEntity> optionalSampleVitalPlayerEntity = sampleVitalPlayerRepository.findById(SampleVitalPlayerEntity.class, uuid);
+
+        if (optionalSampleVitalPlayerEntity.isPresent()) {
+            final SampleVitalPlayerEntity sampleVitalPlayerEntity = optionalSampleVitalPlayerEntity.get();
+
+            sampleVitalPlayerRepository.remove(sampleVitalPlayerEntity);
+        }
+    }
+
+    /**
+     * Just a sample method to show how to communicate with a DB.
+     */
+    public void sampleRepositoryActionMethod() {
+        // Attempt to fetch SampleVitalPlayerEntity from DB.
+        final Optional<SampleVitalPlayerEntity> optionalSampleVitalPlayerEntity = sampleVitalPlayerRepository.findById(SampleVitalPlayerEntity.class, UUID.randomUUID()); // With random UUID
+
+        if (optionalSampleVitalPlayerEntity.isEmpty()) {
+            // Create a new SampleVitalPlayerEntity on DB level.
+            final SampleVitalPlayerEntity sampleVitalPlayerEntity = SampleVitalPlayerEntity.builder()
+                    .uniqueId(UUID.randomUUID())
+                    .name("playerName")
+                    .coins(0)
+                    .level(0)
+                    .build();
+
+            sampleVitalPlayerRepository.persist(sampleVitalPlayerEntity);
+
+            return;
+        }
+
+        // Modify a SampleVitalPlayerEntity on DB level.
+        final SampleVitalPlayerEntity sampleVitalPlayerEntity = optionalSampleVitalPlayerEntity.get();
+
+        sampleVitalPlayerEntity.setCoins(sampleVitalPlayerEntity.getCoins()-100);
+
+        sampleVitalPlayerRepository.persist(sampleVitalPlayerEntity);
+
+        // Get a List of all SampleVitalPlayerEntities.
+        final List<SampleVitalPlayerEntity> sampleVitalPlayerEntityList = sampleVitalPlayerRepository.findAll(SampleVitalPlayerEntity.class);
+
+        // Get a List of all SampleVitalPlayerEntities with the specified DB column values.
+        final List<SampleVitalPlayerEntity> sampleVitalPlayerEntityList1 = sampleVitalPlayerRepository.findAll(SampleVitalPlayerEntity.class,
+                Map.entry("uniqueId", UUID.randomUUID()), // reads from class scoped variables NOT FROM DB COLUMNS!!!
+                Map.entry("name", "playerName")
+        );
+    }
+}

--- a/vital-full-sample/src/main/resources/hibernate.cfg.xml
+++ b/vital-full-sample/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.hbm2ddl.auto">update</property>
+        <property name="hibernate.connection.url">jdbc:mysql://localhost:3306/sample</property>
+        <property name="hibernate.connection.username">root</property>
+        <property name="hibernate.connection.password">root</property>
+        <property name="hibernate.show_sql">true</property>
+        <property name="hibernate.dialect">org.hibernate.dialect.MySQLDialect</property>
+    </session-factory>
+</hibernate-configuration>

--- a/vital-standalone-sample/build.gradle.kts
+++ b/vital-standalone-sample/build.gradle.kts
@@ -13,4 +13,5 @@ dependencies {
     implementation(project(":vital-scoreboards"))
     implementation(project(":vital-players"))
     implementation(project(":vital-minigames"))
+    implementation(project(":vital-databases"))
 }

--- a/vital-standalone-sample/src/main/java/me/xra1ny/vital/sample/standalone/SampleVitalPlugin.java
+++ b/vital-standalone-sample/src/main/java/me/xra1ny/vital/sample/standalone/SampleVitalPlugin.java
@@ -3,6 +3,7 @@ package me.xra1ny.vital.sample.standalone;
 import me.xra1ny.vital.commands.VitalCommandManager;
 import me.xra1ny.vital.core.VitalCore;
 import me.xra1ny.vital.core.VitalListenerManager;
+import me.xra1ny.vital.databases.VitalDatabaseManager;
 import me.xra1ny.vital.holograms.VitalHologramManager;
 import me.xra1ny.vital.items.VitalItemStackManager;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -34,10 +35,15 @@ public class SampleVitalPlugin extends JavaPlugin {
 
             getVitalComponentManager().registerVitalComponent(vitalHologramManager);
 
+            // Here we register Vital's DatabaseManager
+            final VitalDatabaseManager vitalDatabaseManager = new VitalDatabaseManager();
+
+            getVitalComponentManager().registerVitalComponent(vitalDatabaseManager);
+
             // You get the gist, when using this approach you manually have to implement all of Vital's functionality which allows you to fully control which aspect of Vital is present in your project.
-            // If you need more help regarding actually implementing functionality with Vital, follow the example in the `vital-full-sample` module
+            // If you need more help regarding actually implementing functionality with Vital, follow the examples in the `vital-full-sample` module
             // The Implementation of functionality does not differ when using either the full package of vital or the manual implementation explained in this class.
-            // All implementations will always be the same.
+            // All implementations will always be the same in principle.
         }
     };
 


### PR DESCRIPTION
This issue aims to add database support to Vital.

It utilizes the Hibernate Framework to work with OOP in DB.

It aims to implement the same Structure as in the Spring Framework.

Repository -> Has DB access methods
Service -> More complex operations with fetched DB data from repository