### PR TITLE
#50: config serialization

### DIFF
--- a/vital-configs/src/main/java/me/xra1ny/vital/configs/VitalConfigList.java
+++ b/vital-configs/src/main/java/me/xra1ny/vital/configs/VitalConfigList.java
@@ -1,0 +1,12 @@
+package me.xra1ny.vital.configs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface VitalConfigList {
+    Class<? extends VitalConfigSerializable> value();
+}


### PR DESCRIPTION
- fixed private fields in `VitalConfigSerializable`.
- fixed incorrect deserialization Constructor implementation.
- fixed incorrect `List<VitalConfigSerializable>` implementation.
- fixed incorrect recursion in List implementation. VitalConfigSerializables may now recurse to infinity.