### PR TITLE
#48: basic static VitalCommand implementation

### DIFF
--- a/vital-commands/src/main/java/me/xra1ny/vital/commands/VitalCommand.java
+++ b/vital-commands/src/main/java/me/xra1ny/vital/commands/VitalCommand.java
@@ -59,6 +59,121 @@ public abstract class VitalCommand implements AnnotatedVitalComponent<VitalComma
         this.vitalCommandArgs = vitalCommandInfo.args();
     }
 
+    /**
+     * Grabs the `@VitalCommandInfo` Annotation associated with this Command, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Annotation Info you provided, or empty.
+     */
+    public static Optional<VitalCommandInfo> getVitalCommandInfo(@NotNull Class<? extends VitalCommand> type) {
+        return Optional.ofNullable(type.getDeclaredAnnotation(VitalCommandInfo.class));
+    }
+
+    /**
+     * Grabs the Name of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Name of this Command, or empty.
+     */
+    public static Optional<String> getName(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::value);
+    }
+
+    /**
+     * Grabs the Description of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Description of this Command, or empty.
+     */
+    public static Optional<String> getDescription(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::description);
+    }
+
+    /**
+     * Grabs the aliases of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the aliases of this Command, or empty.
+     */
+    public static Optional<String[]> getAliases(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::aliases);
+    }
+
+    /**
+     * Grabs the Usage of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Usage of this Command, or empty.
+     */
+    public static Optional<String> getUsage(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::usage);
+    }
+
+    /**
+     * Grabs the Permission of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Permission of this Command, or empty.
+     */
+    public static Optional<String> getPermission(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::permission);
+    }
+
+    /**
+     * Grabs if this Command requires a Player, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either if this Command requires a Player, or empty.
+     */
+    public static Optional<Boolean> getRequiresPlayer(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::requiresPlayer);
+    }
+
+    /**
+     * Grabs the VitalArgs of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the VitalArgs of this Command, or empty.
+     */
+    public static Optional<VitalCommandArg[]> getVitalArgs(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::args);
+    }
+
+    /**
+     * Grabs the Args of this Command, specified in its respective `@VitalCommandInfo` Annotation on the underlying Child Class, if any.
+     *
+     * @param type The Type of your implementing `VitalCommand` Child Class.
+     * @return An Optional holding either the Args of this Command, or empty.
+     */
+    public static Optional<String[]> getArgs(@NotNull Class<? extends VitalCommand> type) {
+        final Optional<VitalCommandInfo> optionalVitalCommandInfo = getVitalCommandInfo(type);
+
+        return optionalVitalCommandInfo.map(VitalCommandInfo::args)
+                .map(vitalCommandArgs -> {
+                    final List<String> args = new ArrayList<>();
+
+                    for (VitalCommandArg vitalCommandArg : vitalCommandArgs) {
+                        args.add(vitalCommandArg.value());
+                    }
+
+                    return args.toArray(String[]::new);
+                });
+    }
+
     @Override
     public final void onRegistered() {
 
@@ -207,7 +322,6 @@ public abstract class VitalCommand implements AnnotatedVitalComponent<VitalComma
 
         return true;
     }
-
 
     @NotNull
     private VitalCommandReturnState executeCommandArgHandlerMethod(@NotNull CommandSender sender, @NotNull VitalCommandArg commandArg, @NotNull String @NotNull [] values) throws InvocationTargetException, IllegalAccessException {


### PR DESCRIPTION
- VitalCommand meta information may now be fetched statically using `VitalCommand#getVitalCommandInfo(CommandClass)`